### PR TITLE
placeholder for CachedNetworkImage, padding and dimension alterations…

### DIFF
--- a/lib/pages/chat/chat_page.dart
+++ b/lib/pages/chat/chat_page.dart
@@ -1,12 +1,13 @@
 import 'dart:io';
+
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:heartless/backend/controllers/chat_controller.dart';
+import 'package:heartless/main.dart';
 import 'package:heartless/services/date/date_service.dart';
 import 'package:heartless/services/enums/message_type.dart';
 import 'package:heartless/shared/models/app_user.dart';
-import 'package:flutter/material.dart';
-import 'package:heartless/main.dart';
 import 'package:heartless/shared/models/chat.dart';
 import 'package:heartless/shared/models/message.dart';
 import 'package:heartless/shared/provider/auth_notifier.dart';
@@ -92,9 +93,14 @@ class _ChatPageState extends State<ChatPage> with WidgetsBindingObserver {
                       : "https://cdn.icon-icons.com/icons2/1378/PNG/512/avatardefault_92824.png",
                   height: 40,
                   width: 40,
-                  placeholder: (context, url) =>
-                      const CircularProgressIndicator(),
-                  // todo: modify the error widget
+                  placeholder: (context, url) => Center(
+                    child: SizedBox(
+                      height: 20,
+                      width: 20,
+                      child: CircularProgressIndicator(
+                          color: Theme.of(context).canvasColor),
+                    ),
+                  ),
                   errorWidget: (context, url, error) => Container(
                       height: 40,
                       width: 40,

--- a/lib/widgets/chat/chat_tile.dart
+++ b/lib/widgets/chat/chat_tile.dart
@@ -41,9 +41,14 @@ class _ChatTileState extends State<ChatTile> {
                       : "https://cdn.icon-icons.com/icons2/1378/PNG/512/avatardefault_92824.png",
                   height: 52,
                   width: 52,
-                  placeholder: (context, url) =>
-                      const CircularProgressIndicator(),
-                  // todo: modify the error widget
+                  placeholder: (context, url) => Center(
+                    child: SizedBox(
+                      height: 20,
+                      width: 20,
+                      child: CircularProgressIndicator(
+                          color: Theme.of(context).canvasColor),
+                    ),
+                  ),
                   errorWidget: (context, url, error) => Container(
                       height: 52,
                       width: 52,

--- a/lib/widgets/chat/message_tile.dart
+++ b/lib/widgets/chat/message_tile.dart
@@ -1,5 +1,3 @@
-import 'dart:developer';
-
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:heartless/services/storage/file_storage.dart';
@@ -32,7 +30,9 @@ class MessageTile extends StatelessWidget {
           minHeight: 30,
           minWidth: 115,
         ),
-        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+        padding: imageUrl != null && documentUrl == null
+            ? const EdgeInsets.symmetric(horizontal: 5, vertical: 4)
+            : EdgeInsets.symmetric(horizontal: 10, vertical: 5),
         decoration: BoxDecoration(
           color: isSender
               ? (Theme.of(context).brightness == Brightness.dark)
@@ -51,22 +51,31 @@ class MessageTile extends StatelessWidget {
         child: Stack(
           children: [
             Container(
-                padding: const EdgeInsets.only(top: 2, bottom: 10, right: 10),
+                padding: imageUrl != null && documentUrl == null
+                    ? const EdgeInsets.only(top: 0, bottom: 0, right: 0)
+                    : const EdgeInsets.only(top: 2, bottom: 10, right: 10),
                 child: documentUrl == null
                     ? Column(
                         children: [
                           imageUrl != null
                               ? ClipRRect(
-                                  borderRadius: BorderRadius.circular(6),
+                                  borderRadius: BorderRadius.circular(8),
                                   child: CachedNetworkImage(
+                                    fit: BoxFit.cover,
                                     imageUrl: Uri.parse(imageUrl!).isAbsolute
                                         ? imageUrl!
                                         : 'https://via.placeholder.com/150',
-                                    height: 200,
-                                    width: 200,
-                                    placeholder: (context, url) =>
-                                        const CircularProgressIndicator(),
-                                    // todo: modify the error widget
+                                    height: 250,
+                                    width: 250,
+                                    placeholder: (context, url) => Center(
+                                      child: SizedBox(
+                                        height: 20,
+                                        width: 20,
+                                        child: CircularProgressIndicator(
+                                            color:
+                                                Theme.of(context).canvasColor),
+                                      ),
+                                    ),
                                     errorWidget: (context, url, error) =>
                                         Container(
                                             height: 52,
@@ -85,14 +94,25 @@ class MessageTile extends StatelessWidget {
                                   ),
                                 )
                               : const SizedBox(),
-                          Text(
-                            message,
-                            textAlign: TextAlign.start,
-                            style: const TextStyle(
-                                color: Colors.white,
-                                fontSize: 16,
-                                height: 1.2,
-                                fontWeight: FontWeight.w500),
+                          Container(
+                            width: imageUrl != null ? 250 : null,
+                            padding: imageUrl != null && message.isNotEmpty
+                                ? const EdgeInsets.only(
+                                    top: 2,
+                                    bottom: 10,
+                                    right: 10,
+                                    left: 4,
+                                  )
+                                : const EdgeInsets.all(0),
+                            child: Text(
+                              message,
+                              textAlign: TextAlign.start,
+                              style: const TextStyle(
+                                  color: Colors.white,
+                                  fontSize: 16,
+                                  height: 1.2,
+                                  fontWeight: FontWeight.w500),
+                            ),
                           ),
                         ],
                       )
@@ -101,7 +121,6 @@ class MessageTile extends StatelessWidget {
                           if (imageUrl != null) {
                             String? path = await FileStorageService.saveFile(
                                 imageUrl!, message);
-                            log("fodf" + path.toString());
                             if (path != null) FileStorageService.openFile(path);
                           }
                         },


### PR DESCRIPTION
- Custom Circular Progress Indicator added as placeholder for CachedNetworkImage widget at all its occurrences. 
- Fixed Dimensions of 250 * 250 for image in messageTile
-  Different padding for MessageTile at the different scenarios
-- only text message
-- only image 
-- image along with a text message